### PR TITLE
Create content stream blocks

### DIFF
--- a/wagtail_xmlimport/analysis.py
+++ b/wagtail_xmlimport/analysis.py
@@ -17,7 +17,7 @@ class HTMLAnalyzer:
         self.styles_unique_pages = Counter()
         self.classes_unique_pages = Counter()
 
-        self.styles_unique_values = []
+        self.unique_style_strings = []
 
     @classmethod
     def find_all_tags(cls, dom):
@@ -64,17 +64,20 @@ class HTMLAnalyzer:
 
         return styles
 
-    def find_all_unique_styles(self, dom):
+    @classmethod
+    def find_all_unique_style_strings(cls, dom):
+        style_strings = []
         for child in dom.children:
             if isinstance(child, str):
                 continue
 
             for attr_name, attr_value in child.attributes:
                 if attr_name == "style":
-                    if attr_value and attr_value not in self.styles_unique_values:
-                        self.styles_unique_values.append("".join(attr_value))
+                    style_strings.append(attr_value)
 
-            self.find_all_unique_styles(child)
+            cls.find_all_unique_style_strings(child)
+
+        return style_strings
 
     @classmethod
     def find_all_classes(cls, dom):
@@ -105,7 +108,7 @@ class HTMLAnalyzer:
         attributes = self.find_all_attributes(dom)
         styles = self.find_all_styles(dom)
         classes = self.find_all_classes(dom)
-        self.find_all_unique_styles(dom)
+        unique_style_strings = self.find_all_unique_style_strings(dom)
 
         self.tags_total.update(tags)
         self.attributes_total.update(attributes)
@@ -116,3 +119,7 @@ class HTMLAnalyzer:
         self.attributes_unique_pages.update(attributes.keys())
         self.styles_unique_pages.update(styles.keys())
         self.classes_unique_pages.update(classes.keys())
+
+        for style_string in unique_style_strings:
+            if style_string not in self.unique_style_strings:
+                self.unique_style_strings.append(style_string)

--- a/wagtail_xmlimport/bleach.py
+++ b/wagtail_xmlimport/bleach.py
@@ -9,7 +9,7 @@ def bleach_clean(value):
     """
     Clean up the raw html to be on the safe side.
     Keeping all styles in place that we know of and care about.
-    See ALLOWED list above
+    See ALLOWED lists in wagtail-xmlimport/wagtail_xmlimport/constants.py
     """
 
     cleaned = Cleaner(

--- a/wagtail_xmlimport/bleach.py
+++ b/wagtail_xmlimport/bleach.py
@@ -1,5 +1,11 @@
 from bs4 import BeautifulSoup as bs4
-from wagtail_xmlimport.constants import *
+from wagtail_xmlimport.constants import (
+    ALLOWED_TAGS,
+    ALLOWED_STYLES,
+    ALLOWED_ATTRIBUTES,
+    FILTER_MAPPING,
+    HTML_TAGS,
+)
 
 
 from bleach.sanitizer import Cleaner
@@ -37,8 +43,15 @@ def reverse_styles_dict(mapping):
 
 def fix_styles(value):
     """
-    When encounting an inline style that is essitially to make the text
-    bold, remove the style and tag and replace with a b tag
+    This function uses the mapping of the style attribute for an element to break
+    matching elements into one or more html tags.
+    e.g. "font-weight: bold;" maps to "bold" - <b>text</b>
+    e.g. "font-style: italic; font-weight: bold;" maps to "bold-italic" - <b><i>text</i></b>
+
+    It also adds classes which are not directly used in the final content but interpreted
+    later to decide if an element can have alignment in the richtext block
+    e.g. "margin: 0pt 10px 0px 0pt; float: left;" maps to "leftfloat"
+    e.g. "float: left; margin: 0em 1em 1em 0em;" maps to "leftfloat"
     """
     soup = bs4(value, "html.parser")
     search_styles = reverse_styles_dict(FILTER_MAPPING)

--- a/wagtail_xmlimport/block_builder.py
+++ b/wagtail_xmlimport/block_builder.py
@@ -1,0 +1,191 @@
+import requests
+from bs4 import BeautifulSoup
+from django.core.files import File
+from django.core.files.temp import NamedTemporaryFile
+from wagtail.images.models import Image as ImportedImage
+
+TAGS_TO_BLOCKS = [
+    "table",
+    "iframe",
+    "form",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "img",
+    "blockquote",
+]
+IFRAME_POSSIBLE_PARENTS = ["p", "div", "span"]
+
+
+class BlockBuilder:
+    def __init__(self, value):
+        self.soup = BeautifulSoup(value, "lxml", exclude_encodings=True)
+        self.blocks = []
+        self.set_up()
+
+    def set_up(self):
+        """
+        iframes, forms can get put inside a p tag, pull them out
+        extend this to add further tags
+        """
+        for iframe in self.soup.find_all("iframe"):
+            parent = iframe.previous_element
+            if parent.name in IFRAME_POSSIBLE_PARENTS:
+                parent.replaceWith(iframe)
+
+        for form in self.soup.find_all("form"):
+            parent = form.previous_element
+            if parent.name in IFRAME_POSSIBLE_PARENTS:
+                parent.replaceWith(iframe)
+
+        for blockquote in self.soup.find_all("form"):
+            parent = blockquote.previous_element
+            if parent.name in IFRAME_POSSIBLE_PARENTS:
+                parent.replaceWith(iframe)
+
+    def build(self):
+        soup = self.soup.find("body").findChildren(recursive=False)
+        block_value = str("")
+        counter = 0
+
+        for tag in soup:
+            counter += 1
+            """
+            the process here loops though each soup tag to discover the block type to use
+            there's a table and iframe and form block to deal with if they exist
+            """
+
+            # RICHTEXT
+            if not tag.name in TAGS_TO_BLOCKS:
+                block_value += str(self.image_linker(str(tag)))
+
+            # TABLE
+            if tag.name == "table" and len(block_value) > 0:
+                self.blocks.append({"type": "rich_text", "value": block_value})
+                block_value = str("")
+                self.blocks.append({"type": "raw_html", "value": str(tag)})
+
+            # IFRAME/EMBED
+            """
+            test escaped code to add to xml for parsing
+            &lt;iframe width=&quot;560&quot; height=&quot;315&quot; src=&quot;https://www.youtube.com/embed/CQ7Gx8b7ac4&quot; title=&quot;YouTube video player&quot; frameborder=&quot;0&quot; allow=&quot;accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture&quot; allowfullscreen&gt;&lt;/iframe&gt;
+            """
+            if tag.name == "iframe" and len(block_value) > 0:
+                self.blocks.append({"type": "rich_text", "value": block_value})
+                block_value = str("")
+                self.blocks.append(
+                    {
+                        "type": "raw_html",
+                        "value": '<div class="core-custom"><div class="responsive-iframe">{}</div></div>'.format(
+                            str(tag)
+                        ),
+                    }
+                )
+
+            # FORM
+
+            """
+            test escaped code to add to xml for parsing
+            &lt;form&gt;
+            &lt;label for=&quot;fname&quot;&gt;First name:&lt;/label&gt;&lt;br&gt;
+            &lt;input type=&quot;text&quot; id=&quot;fname&quot; name=&quot;fname&quot;&gt;&lt;br&gt;
+            &lt;label for=&quot;lname&quot;&gt;Last name:&lt;/label&gt;&lt;br&gt;
+            &lt;input type=&quot;text&quot; id=&quot;lname&quot; name=&quot;lname&quot;&gt;
+            &lt;/form&gt;
+            """
+            if tag.name == "form" and len(block_value) > 0:
+                self.blocks.append({"type": "rich_text", "value": block_value})
+                block_value = str("")
+                self.blocks.append({"type": "raw_html", "value": str(tag)})
+
+            # HEADING
+            if (
+                tag.name == "h1"
+                or tag.name == "h2"
+                or tag.name == "h3"
+                or tag.name == "h4"
+                or tag.name == "h5"
+                or tag.name == "h6"
+                and len(block_value) > 0
+            ):
+                self.blocks.append({"type": "rich_text", "value": block_value})
+                block_value = str("")
+                self.blocks.append({"type": "raw_html", "value": str(tag)})
+
+            # IMAGE
+            if tag.name == "img" and len(block_value) > 0:
+                self.blocks.append({"type": "rich_text", "value": block_value})
+                block_value = str("")
+                self.blocks.append({"type": "raw_html", "value": str(tag)})
+
+            # BLOCKQUOTE
+            if tag.name == "blockquote" and len(block_value) > 0:
+                self.blocks.append({"type": "rich_text", "value": block_value})
+                block_value = str("")
+                self.blocks.append({"type": "raw_html", "value": str(tag)})
+
+            if counter == len(soup) and len(block_value) > 0:
+                # when we reach the end and something is in the
+                # block_value just output and clear
+                self.blocks.append({"type": "rich_text", "value": block_value})
+                block_value = str("")
+
+        return self.blocks
+
+    def image_linker(self, tag):
+        soup = BeautifulSoup(tag, "html.parser", exclude_encodings=True)
+        images = soup.find_all("img")
+
+        for image in images:
+            image_saved = self.get_image(image)
+            if image_saved:
+                alignment = self.get_alignment_class(image)
+                img_alt = image.attrs["alt"] if "alt" in image.attrs else None
+                tag = '<embed embedtype="image" id="{}" alt="{}" format="{}" />'.format(
+                    image_saved.id, img_alt, alignment
+                )
+
+        return tag
+
+    def get_alignment_class(self, image):
+        alignment = "fullwidth"
+
+        if "class" in image.attrs:
+            if "align-left" in image.attrs["class"]:
+                alignment = "left"
+            elif "align-right" in image.attrs["class"]:
+                alignment = "right"
+
+        return alignment
+
+    def get_image(self, image):
+        name = image.get("src").split("/")[-1]  # need the last part
+        # possible way to check for existing images I used before???
+        # src = "original_images/" + image.get("src").split("/")[-1]  # need the last part
+        temp = NamedTemporaryFile(delete=True)
+
+        try:
+            image_exists = ImportedImage.objects.get(title=name)
+            return image_exists
+
+        except ImportedImage.DoesNotExist:
+
+            try:
+                response = requests.get(image.get("src"), timeout=10, stream=True)
+                if response.status_code == 200:
+                    temp.name = name
+                    temp.write(response.content)
+                    temp.flush()
+                    new_image = ImportedImage(file=File(file=temp), title=name)
+                    new_image.save()
+                    return new_image
+
+            except requests.exceptions.ConnectionError:
+                print(
+                    'WARNING: Unable to connect to URL "{}". Image will be broken.'.format(
+                        image.get("src")
+                    )
+                )

--- a/wagtail_xmlimport/block_builder.py
+++ b/wagtail_xmlimport/block_builder.py
@@ -137,7 +137,7 @@ class BlockBuilder:
                     self.blocks.append({"type": "rich_text", "value": block_value})
                     block_value = str("")
                 cite = ""
-                if tag.attrs and tag.attrs["cite"]:
+                if tag.attrs and tag.attrs.get("cite"):
                     cite = str(tag.attrs["cite"])
                 self.blocks.append(
                     {

--- a/wagtail_xmlimport/blocks.py
+++ b/wagtail_xmlimport/blocks.py
@@ -1,0 +1,70 @@
+from wagtail.core import blocks
+from wagtail.images.blocks import ImageChooserBlock
+
+
+class HeadingBlock(blocks.StructBlock):
+    text = blocks.CharBlock(classname="title")
+    importance = blocks.ChoiceBlock(
+        choices=(
+            ("h1", "H1"),
+            ("h2", "H2"),
+            ("h3", "H3"),
+            ("h4", "H4"),
+            ("h5", "H5"),
+            ("h6", "H6"),
+        ),
+        default="h1",
+    )
+
+    class Meta:
+        icon = "title"
+        template = "wagtail_xmlimport/heading_block.html"
+
+
+class ImageBlock(blocks.StructBlock):
+    image = ImageChooserBlock()
+    caption = blocks.CharBlock(required=False)
+
+    class Meta:
+        icon = "image"
+        template = "wagtail_xmlimport/image_block.html"
+
+
+class QuoteBlock(blocks.StructBlock):
+    quote = blocks.CharBlock(form_classname="title")
+    attribution = blocks.CharBlock(required=False)
+
+    class Meta:
+        icon = "openquote"
+        template = "wagtail_xmlimport/quote_block.html"
+
+
+class WPImportStreamBlocks(blocks.StreamBlock):
+    rich_text = blocks.RichTextBlock(
+        features=[
+            "anchor-identifier",
+            "h1",
+            "h2",
+            "h3",
+            "h4",
+            "h5",
+            "h6",
+            "bold",
+            "italic",
+            "ol",
+            "ul",
+            "hr",
+            "link",
+            "document-link",
+            "image",
+            "embed",
+            "superscript",
+            "subscript",
+            "strikethrough",
+            "blockquote",
+        ]
+    )
+    heading = HeadingBlock()
+    image = ImageBlock()
+    block_quote = QuoteBlock()
+    raw_html = blocks.RawHTMLBlock()

--- a/wagtail_xmlimport/functions.py
+++ b/wagtail_xmlimport/functions.py
@@ -115,11 +115,15 @@ def linebreaks_wp(pee, autoescape=False):
     )  # problem with nested lists
     pee = re.sub(
         r"<p><blockquote([^>]*)>",
-        lambda m: "<blockquote%s><p>" % (m.group(1) if m.group(1) else "",),
+        # lambda m: "<blockquote%s><p>" % (m.group(1) if m.group(1) else "",),
+        # found this not to our liking as it puts a p tag around the blockquote content
+        lambda m: "<blockquote%s>" % (m.group(1) if m.group(1) else "",),
         pee,
         flags=re.IGNORECASE,
     )
-    pee = pee.replace("</blockquote></p>", "</p></blockquote>")
+    # pee = pee.replace("</blockquote></p>", "</p></blockquote>")
+    # found this not to our liking as it puts a p tag around the blockquote content
+    pee = pee.replace("</blockquote></p>", "</blockquote>")
     pee = re.sub(
         r"<p>\s*(</?" + allblocks + r"[^>]*>)",
         lambda m: m.group(1) if m.group(1) else "",

--- a/wagtail_xmlimport/importers/wordpress.py
+++ b/wagtail_xmlimport/importers/wordpress.py
@@ -182,10 +182,12 @@ class WordpressImporter:
 
         # stream fields
         for html in stream_fields:
-            sfv = self.parse_stream_fields(
+            sfv, value, blocks = self.parse_stream_fields(
                 item.get(self.mapping_item_inverse.get(html))
             )
             page_values[html] = sfv
+            page_values["wp_processed_content"] = value
+            page_values["wp_block_json"] = json.dumps(blocks, indent=4)
 
         # dates
         for df in date_fields:
@@ -258,6 +260,4 @@ class WordpressImporter:
         value = fix_styles(str(value))
         value = bleach_clean(str(value))
         blocks = BlockBuilder(value).build()
-        # blocks = []
-        # blocks.append({"type": "raw_html", "value": value}) # handy for viewing the raw html
-        return json.dumps(blocks)
+        return json.dumps(blocks), value, blocks

--- a/wagtail_xmlimport/importers/wordpress.py
+++ b/wagtail_xmlimport/importers/wordpress.py
@@ -5,6 +5,7 @@ from xml.dom import pulldom
 from django.apps import apps
 from django.utils.text import slugify
 from django.utils.timezone import make_aware
+from wagtail.core import blocks
 from wagtail.core.models import Page
 from wagtail_xmlimport.bleach import bleach_clean, fix_styles
 from wagtail_xmlimport.block_builder import BlockBuilder
@@ -257,5 +258,6 @@ class WordpressImporter:
         value = fix_styles(str(value))
         value = bleach_clean(str(value))
         blocks = BlockBuilder(value).build()
+        # blocks = []
         # blocks.append({"type": "raw_html", "value": value}) # handy for viewing the raw html
         return json.dumps(blocks)

--- a/wagtail_xmlimport/importers/wordpress.py
+++ b/wagtail_xmlimport/importers/wordpress.py
@@ -6,10 +6,8 @@ from django.apps import apps
 from django.utils.text import slugify
 from django.utils.timezone import make_aware
 from wagtail.core.models import Page
-from wagtail_xmlimport.bleach import (
-    bleach_clean,
-    fix_styles,
-)
+from wagtail_xmlimport.bleach import bleach_clean, fix_styles
+from wagtail_xmlimport.block_builder import BlockBuilder
 from wagtail_xmlimport.functions import linebreaks_wp, node_to_dict
 from wagtail_xmlimport.importers import wordpress_mapping
 
@@ -22,7 +20,6 @@ class WordpressImporter:
         self.mapping_valid_date = self.mapping.get("validate_date")
         self.mapping_valid_slug = self.mapping.get("validate_slug")
         self.mapping_stream_fields = self.mapping.get("stream_fields")
-        # self.mapping_valid_html = self.mapping.get("validate_html")
         self.mapping_item_inverse = self.map_item_inverse()
         self.log_processed = 0
         self.log_imported = 0
@@ -151,8 +148,6 @@ class WordpressImporter:
         if status == "draft":
             obj.unpublish()
 
-        # self.progress_manager.log_page_action(obj, "updated")
-
         return obj, "updated"
 
     def map_item_inverse(self):
@@ -180,7 +175,6 @@ class WordpressImporter:
         slug_fields = self.mapping_valid_slug.split(",")
 
         stream_fields = self.mapping_stream_fields.split(",")
-        # clean_field = self.mapping_valid_html.split(",")
 
         for field, mapped in self.mapping_item_inverse.items():
             page_values[field] = item[mapped]
@@ -208,36 +202,37 @@ class WordpressImporter:
 
         # if any of the date are not valid then that's important
         date_valid = all(date_valid)
-        # if False in date_valid:
-        #     date_valid = False
-        # else:
-        #     date_valid = True
 
         return page_values, date_valid, slug_changed
 
     def parse_date(self, value):
-        # We need a good date to be able to save the page later and
-        # some dates are not valid date strings in the xml.
-        # If thats the case return a specific date so it can be saved
-        # and return the failure for logging
+        """
+        We need a nice date to be able to save the page later. Some dates are not suitable
+        date strings in the xml. If thats the case return a specific date so it can be saved
+        and return the failure for logging
+        """
         valid = True
         if value == "0000-00-00 00:00:00":
             value = "1900-01-01 00:00:00"  # set this date so it can be found in wagtail admin
             valid = False
-        date = "T".join(value.split(" "))
-        date_formatted = make_aware(datetime.strptime(date, "%Y-%m-%dT%H:%M:%S"))
 
-        return date_formatted, valid
+        date_utc = "T".join(value.split(" "))
+        formatted = make_aware(datetime.strptime(date_utc, "%Y-%m-%dT%H:%M:%S"))
+
+        return formatted, valid
 
     def parse_slug(self, value, title):
-        # log the outcome of slugify
+        """
+        Oddly some page have no slug and some have illegal characters!
+        If None make one from title.
+        Also pass any slug through slugify to be sure and if it's chnaged make a note
+        """
+        changed = None
+
         if not value:
-            # make slug from title
             slug = slugify(title)
             changed = "blank slug"
-
         else:
-            # use exiting slug
             slug = slugify(value)
             changed = "OK"
 
@@ -248,10 +243,19 @@ class WordpressImporter:
         return slug, changed
 
     def parse_stream_fields(self, value):
+        """
+        Here the value is passed through a number of `filters`.
+        They will normalize the html and alter inline styles to suit our needs
+        Finally the normalized content is passed to the BlockBuilder to create
+        the stream fields we need
+
+        Bleach: I'm thinking that bleach clean is removing code that we might want to
+        keep or at least take some action on when fixing the styles so running it before
+        BlockBuilder
+        """
         value = linebreaks_wp(str(value))
         value = fix_styles(str(value))
         value = bleach_clean(str(value))
-        blocks = []
-        # we'll need to create other blocks around here
-        blocks.append({"type": "raw_html", "value": value})
+        blocks = BlockBuilder(value).build()
+        # blocks.append({"type": "raw_html", "value": value}) # handy for viewing the raw html
         return json.dumps(blocks)

--- a/wagtail_xmlimport/importers/wordpress_mapping.py
+++ b/wagtail_xmlimport/importers/wordpress_mapping.py
@@ -5,7 +5,7 @@ mapping = {
         "wp:post_name": "slug",
         "wp:post_date_gmt": "first_published_at",
         "wp:post_modified_gmt": "last_published_at,latest_revision_created_at",
-        "content:encoded": "body",
+        "content:encoded": "body,wp_raw_content",
         "wp:post_id": "wp_post_id",
         "wp:post_type": "wp_post_type",
         "link": "wp_link",

--- a/wagtail_xmlimport/management/commands/analyze_html_content.py
+++ b/wagtail_xmlimport/management/commands/analyze_html_content.py
@@ -8,6 +8,26 @@ from wagtail_xmlimport.analysis import HTMLAnalyzer
 
 
 class Command(BaseCommand):
+    help = """This command is not used directly in an import.
+
+    It's a tool to help you see and understand the html tags in the content as well as the inline styles found.
+
+    It ouputs a series of tables to the command line.
+    The ouput is ideally used inside a spreadsheet by piping it out to a file and importing it.
+    Hint: Use the | as a column separator when importing
+
+    Use a command like: ./manage.py analyze_html_content [your_source_xml_file] > analysis.txt
+    Then remove the titles and horizontal table lines so it looks like:
+
+    |    Tag     | Pages used on | Total occurrences |
+    |     p      |      2504     |       41696       |
+    |     a      |      2433     |       19646       |
+    |   strong   |      2147     |       21020       |
+    ...
+
+    and save each table to a separate file for later import.
+    """
+
     def add_arguments(self, parser):
         parser.add_argument("xml_file", type=str, help="The full path to your xml file")
         parser.add_argument(
@@ -50,20 +70,41 @@ class Command(BaseCommand):
 
         # Attributes
         attributes_table = PrettyTable()
-        attributes_table.field_names = ["Tag", "Attribute", "Pages used on", "Total occurrences", "Diff"]
-        for (tag, attribute), total_pages in analyzer.attributes_unique_pages.most_common():
-            diff = diff_tags[tag] - analyzer.attributes_total[(tag, attribute)]
-            attributes_table.add_row([tag, attribute, total_pages, analyzer.attributes_total[(tag, attribute)], diff])
+        attributes_table.field_names = [
+            "Tag",
+            "Attribute",
+            "Pages used on",
+            "Total occurrences",
+        ]
+        for (
+            tag,
+            attribute,
+        ), total_pages in analyzer.attributes_unique_pages.most_common():
+            attributes_table.add_row(
+                [
+                    tag,
+                    attribute,
+                    total_pages,
+                    analyzer.attributes_total[(tag, attribute)],
+                ]
+            )
 
         self.stdout.write("")
-        self.stdout.write("Most commonly used HTML attributes. Diff > 0 indicates is missing the attr vs usage")
+        self.stdout.write("Most commonly used HTML attributes.")
         self.stdout.write(str(attributes_table))
 
         # Styles
         styles_table = PrettyTable()
-        styles_table.field_names = ["Tag", "Style", "Pages used on", "Total occurrences"]
+        styles_table.field_names = [
+            "Tag",
+            "Style",
+            "Pages used on",
+            "Total occurrences",
+        ]
         for (tag, style), total_pages in analyzer.styles_unique_pages.most_common():
-            styles_table.add_row([tag, style, total_pages, analyzer.styles_total[(tag, style)]])
+            styles_table.add_row(
+                [tag, style, total_pages, analyzer.styles_total[(tag, style)]]
+            )
 
         self.stdout.write("")
         self.stdout.write("Most commonly used inline CSS styles")
@@ -77,7 +118,6 @@ class Command(BaseCommand):
         self.stdout.write("")
         self.stdout.write("Unique inline CSS style values")
         self.stdout.write(str(styles_values_table))
-
 
     def get_xml_file(self, xml_file):
         if os.path.exists(xml_file):

--- a/wagtail_xmlimport/management/commands/analyze_html_content.py
+++ b/wagtail_xmlimport/management/commands/analyze_html_content.py
@@ -56,13 +56,10 @@ class Command(BaseCommand):
             page_statuses=options["status"].split(","),
         )
 
-        diff_tags = {}
-
         # Tags
         tags_table = PrettyTable()
         tags_table.field_names = ["Tag", "Pages used on", "Total occurrences"]
         for tag, total_pages in analyzer.tags_unique_pages.most_common():
-            diff_tags[tag] = analyzer.tags_total[tag]
             tags_table.add_row([tag, total_pages, analyzer.tags_total[tag]])
 
         self.stdout.write("Most commonly used HTML tags")
@@ -112,11 +109,11 @@ class Command(BaseCommand):
 
         styles_values_table = PrettyTable()
         styles_values_table.field_names = ["Style Value"]
-        for value in analyzer.styles_unique_values:
+        for value in analyzer.unique_style_strings:
             styles_values_table.add_row([value])
 
         self.stdout.write("")
-        self.stdout.write("Unique inline CSS style values")
+        self.stdout.write("Unique inline CSS style values as strings")
         self.stdout.write(str(styles_values_table))
 
     def get_xml_file(self, xml_file):

--- a/wagtail_xmlimport/models.py
+++ b/wagtail_xmlimport/models.py
@@ -1,5 +1,5 @@
 from django.db import models
-from wagtail.admin.edit_handlers import FieldPanel, ObjectList, TabbedInterface
+from wagtail.admin.edit_handlers import FieldPanel, FieldRowPanel
 from wagtail.core.models import Page
 
 
@@ -7,21 +7,20 @@ class WPImportedPageMixin(Page):
     wp_post_id = models.IntegerField(blank=True, null=True)
     wp_post_type = models.CharField(max_length=255, blank=True, null=True)
     wp_link = models.TextField(blank=True, null=True)
+    wp_raw_content = models.TextField(blank=True, null=True)
+    wp_processed_content = models.TextField(blank=True, null=True)
+    wp_block_json = models.TextField(blank=True, null=True)
 
     class Meta:
         abstract = True
 
     wordpress_panels = [
-        FieldPanel("wp_post_id"), 
-        FieldPanel("wp_post_type"),
-        FieldPanel("wp_link")
+        FieldRowPanel([
+            FieldPanel("wp_post_id"), 
+            FieldPanel("wp_post_type"),
+        ], heading="wp data"),
+        FieldPanel("wp_link", classname="full title"),
+        FieldPanel("wp_block_json", classname="full"),        
+        FieldPanel("wp_processed_content", classname="full"),
+        FieldPanel("wp_raw_content", classname="full"),
     ]
-
-    edit_handler = TabbedInterface(
-        [
-            ObjectList(Page.content_panels, heading="Content"),
-            ObjectList(Page.promote_panels, heading="Promote"),
-            ObjectList(Page.settings_panels, heading="Settings", classname="settings"),
-            ObjectList(wordpress_panels, heading="Wordpress Data"),
-        ]
-    )

--- a/wagtail_xmlimport/templates/wagtail_xmlimport/heading_block.html
+++ b/wagtail_xmlimport/templates/wagtail_xmlimport/heading_block.html
@@ -1,0 +1,1 @@
+<{{value.importance}}>{{ value.text }}</{{value.importance}}>

--- a/wagtail_xmlimport/templates/wagtail_xmlimport/image_block.html
+++ b/wagtail_xmlimport/templates/wagtail_xmlimport/image_block.html
@@ -1,0 +1,4 @@
+{% load wagtailimages_tags %}
+
+{% image value.image width-1000 loading="lazy" %}
+<p>{{ value.caption }}</p>

--- a/wagtail_xmlimport/templates/wagtail_xmlimport/quote_block.html
+++ b/wagtail_xmlimport/templates/wagtail_xmlimport/quote_block.html
@@ -1,0 +1,4 @@
+<blockquote>
+    <p>{{ value.quote }}</p>
+    {% if value.attribution %}{{ value.attribution }}{% endif %}
+</blockquote>

--- a/wagtail_xmlimport/test/tests/test_bleach.py
+++ b/wagtail_xmlimport/test/tests/test_bleach.py
@@ -49,9 +49,8 @@ class TestBleach(TestCase):
         self.assertEqual(lb_wp.count("\n"), OUTPUT_SINGLE_LINES_OCCURANCE_TOTAL)
         self.assertEqual(lb_wp.count("<p"), OUTPUT_P_OCCURANCE_TOTAL)
 
-    def test_fix_styles(self):
-        value = self.stream
-        value = linebreaks_wp(value)
-        value = fix_styles(value)
-        value = bleach_clean(value)
-        print(value)
+    # def test_fix_styles(self):
+    #     value = self.stream
+    #     value = linebreaks_wp(value)
+    #     value = fix_styles(value)
+    #     value = bleach_clean(value)

--- a/wagtail_xmlimport/test/tests/test_block_builder.py
+++ b/wagtail_xmlimport/test/tests/test_block_builder.py
@@ -1,0 +1,11 @@
+from django.test import TestCase
+from wagtail_xmlimport.block_builder import check_image_src
+
+class TestBlockBuilder(TestCase):
+
+    def test_check_image_src(self):
+        src1 = "https://www.budgetsaresexy.com/folder/myimage.gif"
+        src2 = "folder/myimage.gif"
+
+        self.assertEqual(check_image_src(src1), "https://www.budgetsaresexy.com/folder/myimage.gif")
+        self.assertEqual(check_image_src(src2), "https://www.budgetsaresexy.com/folder/myimage.gif")


### PR DESCRIPTION
This breaks content into individual stream blocks. 

- `RawHTMLBlock`
- `HeadingBlock` - with fields for level and id
    - For example: `<h1 id="title">` would be converted to `HeadingBlock(level=1, id='title')` (ID’s seem to be really common in Wordpress)
- `ParagraphBlock`
- `BlockQuoteBlock`

The original spec. also defines Image and Embed blocks