### PR TITLE
Fixes a bug present on windows, which does not support the delete key…

### DIFF
--- a/wagtail_wordpress_import/block_builder_defaults.py
+++ b/wagtail_wordpress_import/block_builder_defaults.py
@@ -121,7 +121,7 @@ def get_or_save_image(src):
                 ],
             )
         ):
-            temp_image = NamedTemporaryFile(delete=True)
+            temp_image = NamedTemporaryFile()
             temp_image.name = image_file_name
             temp_image.write(response.content)
             temp_image.flush()
@@ -202,7 +202,7 @@ def get_or_save_document(href):
                     ],
                 )
             ):
-                temp_document = NamedTemporaryFile(delete=True)
+                temp_document = NamedTemporaryFile()
                 temp_document.name = document_file_name
                 temp_document.write(response.content)
                 temp_document.flush()

--- a/wagtail_wordpress_import/test/tests/xml_boilerplate.py
+++ b/wagtail_wordpress_import/test/tests/xml_boilerplate.py
@@ -32,7 +32,7 @@ def build_xml_stream(xml_tags_fragment="", xml_items_fragment=""):
 
 def generate_temporay_file(xml_stream):
 
-    temp_file = tempfile.NamedTemporaryFile(delete=False)
+    temp_file = tempfile.NamedTemporaryFile()
 
     with open(temp_file.name, "w") as f:
         f.write(xml_stream)

--- a/wagtail_wordpress_import/xml_boilerplate.py
+++ b/wagtail_wordpress_import/xml_boilerplate.py
@@ -32,7 +32,7 @@ def build_xml_stream(xml_tags_fragment="", xml_items_fragment=""):
 
 def generate_temporary_file(xml_stream):
 
-    temp_file = tempfile.NamedTemporaryFile(delete=False)
+    temp_file = tempfile.NamedTemporaryFile()
 
     with open(temp_file.name, "w") as f:
         f.write(xml_stream)


### PR DESCRIPTION
This fix corrects an issue with the named temporary file in the xml importer. 

This issue is caused by the use of the NamedTemporaryFile from Django's implementation, which is not meant for external use and does not implement several keywords: https://code.djangoproject.com/wiki/NamedTemporaryFile

The other option for this solution would be to use the python language named temporary file, which may not work properly on windows systems as well: https://docs.python.org/3/library/tempfile.html