### PR TITLE
prefilters: fix crash due to class being a string not list

### DIFF
--- a/wagtail_wordpress_import/prefilters/transform_styles_defaults.py
+++ b/wagtail_wordpress_import/prefilters/transform_styles_defaults.py
@@ -1,5 +1,16 @@
 from django.conf import settings
 
+def __append_or_set(tag, key, value):
+    if tag.attrs.get(key):
+        # The key class can be a string or list
+        # so copy the mode that is being used currently
+        # https://beautiful-soup-4.readthedocs.io/en/latest/index.html?highlight=find_all#multi-valued-attributes
+        if type(tag.attrs[key]) is str:
+            tag.attrs[key] += " " + value
+        else:
+            tag.attrs[key].append(value)
+    else:
+        tag.attrs[key] = value
 
 def transform_style_bold(soup, tag):
     """
@@ -34,50 +45,35 @@ def transform_style_center(soup, tag):
     """
     apply a new css class to any existing classes
     """
-    if tag.attrs.get("class"):
-        tag.attrs["class"].append("align-center")
-    else:
-        tag.attrs["class"] = "align-center"
+    __append_or_set(tag, "class", "align-center")
 
 
 def transform_style_left(soup, tag):
     """
     apply a new css class to any existing classes
     """
-    if tag.attrs.get("class"):
-        tag.attrs["class"].append("align-left")
-    else:
-        tag.attrs["class"] = "align-left"
+    __append_or_set(tag, "class", "align-left")
 
 
 def transform_style_right(soup, tag):
     """
     apply a new css class to any existing classes
     """
-    if tag.attrs.get("class"):
-        tag.attrs["class"].append("align-right")
-    else:
-        tag.attrs["class"] = "align-right"
+    __append_or_set(tag, "class", "align-right")
 
 
 def transform_float_left(soup, tag):
     """
     apply a new css class to any existing classes
     """
-    if tag.attrs.get("class"):
-        tag.attrs["class"].append("float-left")
-    else:
-        tag.attrs["class"] = "float-left"
+    __append_or_set(tag, "class", "float-left")
 
 
 def transform_float_right(soup, tag):
     """
     apply a new css class to any existing classes
     """
-    if tag.attrs.get("class"):
-        tag.attrs["class"].append("float-right")
-    else:
-        tag.attrs["class"] = "float-right"
+    __append_or_set(tag, "class", "float-right")
 
 
 def transform_html_tag_strong(soup, tag):


### PR DESCRIPTION
Some tags can be either a str or a list which can cause a crash in the existing filters.
https://beautiful-soup-4.readthedocs.io/en/latest/index.html?highlight=find_all#multi-valued-attributes

Traceback (most recent call last):
  File "/var/home/andrew/Projects/web/wagtail-example/mysite/manage.py", line 10, in <module>
    execute_from_command_line(sys.argv)
  File "/var/home/andrew/Projects/web/wagtail-example/mysite/env/lib/python3.10/site-packages/django/core/management/__init__.py", line 442, in execute_from_command_line
    utility.execute()
  File "/var/home/andrew/Projects/web/wagtail-example/mysite/env/lib/python3.10/site-packages/django/core/management/__init__.py", line 436, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/var/home/andrew/Projects/web/wagtail-example/mysite/env/lib/python3.10/site-packages/django/core/management/base.py", line 412, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/var/home/andrew/Projects/web/wagtail-example/mysite/env/lib/python3.10/site-packages/django/core/management/base.py", line 458, in execute
    output = self.handle(*args, **options)
  File "/var/home/andrew/Projects/web/wagtail-example/mysite/env/lib/python3.10/site-packages/wagtail_wordpress_import/management/commands/import_xml.py", line 71, in handle
    importer.run(
  File "/var/home/andrew/Projects/web/wagtail-example/mysite/env/lib/python3.10/site-packages/wagtail_wordpress_import/importers/wordpress.py", line 125, in run
    wp_post_id=wordpress_item.cleaned_data.get("wp_post_id")
  File "/usr/lib/python3.10/functools.py", line 981, in __get__
    val = self.func(instance)
  File "/var/home/andrew/Projects/web/wagtail-example/mysite/env/lib/python3.10/site-packages/wagtail_wordpress_import/importers/wordpress.py", line 530, in cleaned_data
    "body": self.body_stream_field(self.prefilter_content(self.raw_body)),
  File "/var/home/andrew/Projects/web/wagtail-example/mysite/env/lib/python3.10/site-packages/wagtail_wordpress_import/importers/wordpress.py", line 373, in prefilter_content
    cached_result = function(cached_result, filter.get("OPTIONS"))
  File "/var/home/andrew/Projects/web/wagtail-example/mysite/env/lib/python3.10/site-packages/wagtail_wordpress_import/prefilters/transform_styles_filter.py", line 104, in filter_transform_inline_styles
    filter_transform_styles(
  File "/var/home/andrew/Projects/web/wagtail-example/mysite/env/lib/python3.10/site-packages/wagtail_wordpress_import/prefilters/transform_styles_filter.py", line 123, in filter_transform_styles
    filter_method(soup, tag)
  File "/var/home/andrew/Projects/web/wagtail-example/mysite/env/lib/python3.10/site-packages/wagtail_wordpress_import/prefilters/transform_styles_defaults.py", line 68, in transform_float_left
    tag.attrs["class"].append("float-left")
AttributeError: 'str' object has no attribute 'append'

# (Description)

<!-- Describe your pull request, and instructions for the reviewer. -->

Ticket URL:

---

<!-- Please tick or remove these as relevant. Provide further details if valuable. Be pragmatic. -->

Testing

- [ ] CI passes
- [ ] If necessary, tests are added for new or fixed behaviour
- [ ] These changes do not reduce test coverage

Documentation.

- [ ] This PR adds or updates documentation
- [ ] Documentation changes are not necessary because:
