### PR TITLE
Improve CSV Logging and Fix Image Import Handling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
   - repo: https://github.com/pycqa/flake8

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
             "freezegun==0.3.15",
             "responses>=0.16.0,<0.17.0",
             "flake8==5.0.4",
-            "isort==5.10.1",
+            "isort==5.12.0",
             "black==22.10.0",
         ],
     },

--- a/wagtail_wordpress_import/block_builder.py
+++ b/wagtail_wordpress_import/block_builder.py
@@ -111,8 +111,9 @@ class BlockBuilder:
                     cached_fallback_value = cached_fallback_function(
                         cached_fallback_value,
                         self.blocks,
+                        logger=self.logger,
                     )  # before building a block write fall back cache to a block
-                self.blocks.append(builder_function(element))
+                self.blocks.append(builder_function(element, logger=self.logger))
             else:
                 if element.text.strip():  # exclude a tag that is empty
                     cached_fallback_value += str(element)
@@ -121,7 +122,7 @@ class BlockBuilder:
                 soup
             ):  # the last tag so just build whats left in the fall back cache
                 cached_fallback_value = cached_fallback_function(
-                    cached_fallback_value, self.blocks
+                    cached_fallback_value, self.blocks, logger=self.logger
                 )
 
         return self.blocks

--- a/wagtail_wordpress_import/block_builder_defaults.py
+++ b/wagtail_wordpress_import/block_builder_defaults.py
@@ -67,7 +67,7 @@ def fetch_url(src, allow_redirects=True):
 # FUNCTIONS FOR IMAGES
 
 
-def image_linker(html):
+def image_linker(html, logger=None):
     """
     params
     ======
@@ -89,7 +89,7 @@ def image_linker(html):
                 image.attrs["src"],
                 getattr(settings, "WAGTAIL_WORDPRESS_IMPORTER_SOURCE_DOMAIN"),
             )
-            saved_image = get_or_save_image(image_src)
+            saved_image = get_or_save_image(image_src, logger=logger)
             if saved_image:
                 image_embed = soup.new_tag("embed")
                 image_embed.attrs["embedtype"] = "image"
@@ -103,7 +103,7 @@ def image_linker(html):
     return str(soup)
 
 
-def get_or_save_image(src):
+def get_or_save_image(src, logger=None):
     image_file_name = get_image_file_name(src)
     existing_image = image_exists(image_file_name)
     if not existing_image:
@@ -128,18 +128,43 @@ def get_or_save_image(src):
             retrieved_image = ImportedImage(
                 file=File(file=temp_image), title=image_file_name
             )
-            retrieved_image.save()
+            try:
+                retrieved_image.save()
+            except Exception as e:
+                if logger:
+                    logger.images.append(
+                        {
+                            "id": 0,
+                            "title": image_file_name,
+                            "link": src,
+                            "reason": f"ImportedImage.save() error: {e}",
+                        }
+                    )
+                else:
+                    print(f"ImportedImage.save() error: {e}")
+                return None
+
             temp_image.close()
             return retrieved_image
         else:
-            print(f"RECEIVED INVALID IMAGE RESPONSE: {src}")
+            if logger:
+                logger.images.append(
+                    {
+                        "id": 0,
+                        "title": image_file_name,
+                        "link": src,
+                        "reason": f"RECEIVED INVALID IMAGE RESPONSE: {src}",
+                    }
+                )
+            else:
+                print(f"RECEIVED INVALID IMAGE RESPONSE: {src}")
     return existing_image
 
 
 # FUNCTIONS FOR DOCUMENTS
 
 
-def document_linker(html):
+def document_linker(html, logger=None):
     """
     params
     ======
@@ -220,7 +245,7 @@ def get_or_save_document(href):
 # STREAMFIELD BLOCKS
 
 
-def build_block_quote_block(tag):
+def build_block_quote_block(tag, **kwargs):
     block_dict = {
         "type": "block_quote",
         "value": {"quote": tag.text.strip(), "attribution": tag.cite},
@@ -228,12 +253,12 @@ def build_block_quote_block(tag):
     return block_dict
 
 
-def build_form_block(tag):
+def build_form_block(tag, **kwargs):
     block_dict = {"type": "raw_html", "value": str(tag)}
     return block_dict
 
 
-def build_heading_block(tag):
+def build_heading_block(tag, **kwargs):
     block_dict = {
         "type": "heading",
         "value": {"importance": tag.name, "text": tag.text},
@@ -241,7 +266,7 @@ def build_heading_block(tag):
     return block_dict
 
 
-def build_iframe_block(tag):
+def build_iframe_block(tag, **kwargs):
     block_dict = {
         "type": "raw_html",
         "value": '<div class="core-custom"><div class="responsive-iframe">{}</div></div>'.format(
@@ -251,7 +276,7 @@ def build_iframe_block(tag):
     return block_dict
 
 
-def build_image_block(tag):
+def build_image_block(tag, **kwargs):
     def get_image_id(src):
         return 1
 
@@ -259,7 +284,7 @@ def build_image_block(tag):
     return block_dict
 
 
-def build_table_block(tag):
+def build_table_block(tag, **kwargs):
     block_dict = {"type": "raw_html", "value": str(tag)}
     return block_dict
 
@@ -275,14 +300,15 @@ def conf_fallback_block():
     )
 
 
-def build_richtext_block_content(html, blocks):
+def build_richtext_block_content(html, blocks, **kwargs):
     """
     image_linker is called to link up and retrive the remote image
     document_linker is called to link up and retrive the remote documents
     filters are called to replace inline shortcodes
     """
-    html = image_linker(html)
-    html = document_linker(html)
+    logger = kwargs.get("logger")
+    html = image_linker(html, logger=logger)
+    html = document_linker(html, logger=logger)
     for inline_shortcode_handler in getattr(
         settings, "WAGTAIL_WORDPRESS_IMPORTER_INLINE_SHORTCODE_HANDLERS", []
     ):

--- a/wagtail_wordpress_import/importers/wordpress.py
+++ b/wagtail_wordpress_import/importers/wordpress.py
@@ -76,7 +76,7 @@ class WordpressImporter:
             )
         except LookupError:
             print(
-                f"The app `{kwargs['app_for_pages']}` and/or page model `{kwargs['model_for_pages']}` cannot be found!"
+                f"The app '{kwargs['app_for_pages']}' and/or page model '{kwargs['model_for_pages']}' cannot be found!"
             )
             print(
                 "Check the command line options -a and -m match an existing Wagtail app and Wagtail page model"

--- a/wagtail_wordpress_import/logger.py
+++ b/wagtail_wordpress_import/logger.py
@@ -107,7 +107,7 @@ class Logger:
 
     def _write_csv(self, file_suffix, data, fieldnames, header_mapping, row_map=None):
         file_name = f"{self.logdir}/{file_suffix}-{datetime.now().strftime('%Y%m%d-%H%M%S')}.csv"
-        
+
         with open(file_name, "w", newline="") as csvfile:
             writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
             writer.writerow(header_mapping)

--- a/wagtail_wordpress_import/logger.py
+++ b/wagtail_wordpress_import/logger.py
@@ -49,100 +49,68 @@ class Logger:
             )
 
     def save_csv_import_report(self):
-        file_name = f"{self.logdir}/import-report-{datetime.now().strftime('%Y%m%d-%H%M%S')}.csv"
-
-        with open(file_name, "w", newline="") as csvfile:
-            writer = csv.DictWriter(
-                csvfile,
-                fieldnames=[
-                    "id",
-                    "title",
-                    "url",
-                    "reason",
-                    "result",
-                    "dates",
-                    "slug",
-                ],
-            )
-            writer.writerow(
-                {
-                    "id": "Page ID",
-                    "title": "Page Title",
-                    "url": "Wordpress Link",
-                    "reason": "Reason for result ->",
-                    "result": "Result",
-                    "dates": "Dates Changed",
-                    "slug": "Slug Changed",
-                }
-            )
-            for row in self.items:
-                writer.writerow(
-                    {
-                        "id": row["id"],
-                        "title": row["title"],
-                        "url": row["link"],
-                        "reason": row["reason"],
-                        "result": row["result"],
-                        "dates": row["datecheck"],
-                        "slug": row["slugcheck"],
-                    }
-                )
+        self._write_csv(
+            "import-report",
+            self.items,
+            ["id", "title", "url", "reason", "result", "dates", "slug"],
+            {
+                "id": "Page ID",
+                "title": "Page Title",
+                "url": "Wordpress Link",
+                "reason": "Reason for result ->",
+                "result": "Result",
+                "dates": "Dates Changed",
+                "slug": "Slug Changed",
+            },
+            row_map=lambda row: {
+                "id": row["id"],
+                "title": row["title"],
+                "url": row["link"],
+                "reason": row["reason"],
+                "result": row["result"],
+                "dates": row["datecheck"],
+                "slug": row["slugcheck"],
+            },
+        )
 
     def save_csv_images_report(self):
-        file_name = f"{self.logdir}/images-report-{datetime.now().strftime('%Y%m%d-%H%M%S')}.csv"
-
-        with open(file_name, "w", newline="") as csvfile:
-            writer = csv.DictWriter(
-                csvfile,
-                fieldnames=[
-                    "id",
-                    "title",
-                    "url",
-                    "reason",
-                ],
-            )
-            writer.writerow(
-                {
-                    "id": "Page ID",
-                    "title": "Page Title",
-                    "url": "Wordpress Link",
-                    "reason": "Reason",
-                }
-            )
-            for row in self.images:
-                writer.writerow(
-                    {
-                        "id": row["id"],
-                        "title": row["title"],
-                        "url": row["link"],
-                        "reason": row["reason"],
-                    }
-                )
+        self._write_csv(
+            "images-report",
+            self.images,
+            ["id", "title", "url", "reason"],
+            {
+                "id": "Page ID",
+                "title": "Page Title",
+                "url": "Wordpress Link",
+                "reason": "Reason",
+            },
+            row_map=lambda row: {
+                "id": row["id"],
+                "title": row["title"],
+                "url": row["link"],
+                "reason": row["reason"],
+            },
+        )
 
     def save_csv_pagelink_errors_report(self):
-        file_name = f"{self.logdir}/pagelink_errors-report-{datetime.now().strftime('%Y%m%d-%H%M%S')}.csv"
+        # self.page_link_errors is a list of tuples (link, page_object)
+        data = [
+            {"id": page.id, "title": page.title, "link": link}
+            for link, page in self.page_link_errors
+        ]
+        self._write_csv(
+            "pagelink_errors-report",
+            data,
+            ["id", "title", "link"],
+            {"id": "Page ID", "title": "Page Title", "link": "Wordpress Link"},
+        )
 
+    def _write_csv(self, file_suffix, data, fieldnames, header_mapping, row_map=None):
+        file_name = f"{self.logdir}/{file_suffix}-{datetime.now().strftime('%Y%m%d-%H%M%S')}.csv"
+        
         with open(file_name, "w", newline="") as csvfile:
-            writer = csv.DictWriter(
-                csvfile,
-                fieldnames=[
-                    "id",
-                    "title",
-                    "link",
-                ],
-            )
-            writer.writerow(
-                {
-                    "id": "Page ID",
-                    "title": "Page Title",
-                    "link": "Wordpress Link",
-                }
-            )
-            for row in self.images:
-                writer.writerow(
-                    {
-                        "id": row["id"],
-                        "title": row["title"],
-                        "link": row["link"],
-                    }
-                )
+            writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+            writer.writerow(header_mapping)
+            for item in data:
+                row = row_map(item) if row_map else item
+                writer.writerow(row)

--- a/wagtail_wordpress_import/management/commands/reduce_xml.py
+++ b/wagtail_wordpress_import/management/commands/reduce_xml.py
@@ -36,7 +36,7 @@ class Command(BaseCommand):
             return xml_file
 
         self.stdout.write(
-            self.style.ERROR(f"The xml file `{xml_file}` cannot be found")
+            self.style.ERROR(f"The xml file '{xml_file}' cannot be found")
         )
         exit()
 

--- a/wagtail_wordpress_import/prefilters/handle_shortcodes.py
+++ b/wagtail_wordpress_import/prefilters/handle_shortcodes.py
@@ -125,26 +125,40 @@ class CaptionHandler(BlockShortcodeHandler):
 
     shortcode_name = "caption"
 
-    def construct_block(self, soup):
+    def construct_block(self, soup, **kwargs):
         """Construct a StreamBlock dict that's passed back to the block builder
 
         soup: <class 'bs4.element.Tag'>
         """
+        logger = kwargs.get("logger")
 
         # Without an image the caption shortcode is useless
         # Here we'll add a raw HTML block to the stream so in admin
         # it can be seen and some action taken.
         image = soup.find("img")
         if not image:
+            if logger:
+                logger.images.append(
+                    {
+                        "id": 0,
+                        "title": "Unknown",
+                        "link": "",
+                        "reason": f"No image found in caption {soup}",
+                    }
+                )
             return {
                 "type": "raw_html",
                 "value": f"<!-- No image found in caption {soup}-->",
             }
-        # TODO: Output this in logging when we have a logger
-        # https://projects.torchbox.com/projects/wordpress-to-wagtail-importer-package/tickets/63
 
         # Parse the image
-        image_file = get_or_save_image(image.attrs["src"])
+        image_file = get_or_save_image(image.attrs["src"], logger=logger)
+
+        if not image_file:
+            return {
+                "type": "raw_html",
+                "value": f"<!-- Image could not be imported in caption {soup}-->",
+            }
 
         # Parse alignment
         if "align" in soup.attrs:

--- a/wagtail_wordpress_import/test/tests/test_block_builder.py
+++ b/wagtail_wordpress_import/test/tests/test_block_builder.py
@@ -74,7 +74,7 @@ class TestBlockBuilderRemoveParents(TestCase):
         wagtail_block_captions = output.find_all("wagtail_block_caption")
         for idx, wagtail_block_caption in enumerate(wagtail_block_captions):
             with self.subTest(
-                f"Checking that both wagtail_block_caption tags are top level elements fixture:{idx}"
+                f"Checking that both wagtail_block_caption tags are top level elements fixture: {idx}"
             ):
                 self.assertTrue(
                     wagtail_block_caption.parent.name == self.expected_parent_name


### PR DESCRIPTION
# Improve CSV Logging and Fix Image Import Handling

Closes #193
Closes #142
Closes #145
Closes #171

## Description

This PR addresses the "Make the logging to CSV better" issue and resolves several sub-issues related to failures and missing logs during image import.

### Key Changes:

1.  **Refactored CSV Logging ([logger.py](cci:7://file:///Users/himanshugupta/Developer/wagtail-wordpress-import/wagtail_wordpress_import/logger.py:0:0-0:0))**:
    -   Consolidated CSV writing logic into a new [_write_csv](cci:1://file:///Users/himanshugupta/Developer/wagtail-wordpress-import/wagtail_wordpress_import/logger.py:107:4-115:36) helper method to reduce code duplication.
    -   **Fix:** Corrected [save_csv_pagelink_errors_report](cci:1://file:///Users/himanshugupta/Developer/wagtail-wordpress-import/wagtail_wordpress_import/logger.py:94:4-105:9) which was previously iterating over `self.images` (causing incorrect data or crashes) instead of `self.page_link_errors`. It now correctly extracts and logs page link errors.

2.  **Robust Image Import Handling**:
    -   **Fix #142 (Crash on None Image):** Updated [CaptionHandler](cci:2://file:///Users/himanshugupta/Developer/wagtail-wordpress-import/wagtail_wordpress_import/prefilters/handle_shortcodes.py:100:0-188:9) to gracefully handle cases where [get_or_save_image](cci:1://file:///Users/himanshugupta/Developer/wagtail-wordpress-import/wagtail_wordpress_import/block_builder_defaults.py:105:0-160:25) fails (returns `None`) instead of crashing with an `AttributeError`. A fallback HTML comment is now generated in the stream block.
    -   **Fix #145 (Corrupted Image):** Wrapped the image save operation in [get_or_save_image](cci:1://file:///Users/himanshugupta/Developer/wagtail-wordpress-import/wagtail_wordpress_import/block_builder_defaults.py:105:0-160:25) with a `try/except` block to catch `IntegrityError` (e.g., width=0) or other exceptions caused by corrupted files.
    -   **Fix #171 (Missing Logs):** Refactored [BlockBuilder](cci:2://file:///Users/himanshugupta/Developer/wagtail-wordpress-import/wagtail_wordpress_import/block_builder.py:29:0-127:26) and default builder functions to accept and pass the [Logger](cci:2://file:///Users/himanshugupta/Developer/wagtail-wordpress-import/wagtail_wordpress_import/logger.py:5:0-115:36) instance down the call stack. This ensures that deep failures (like in [get_or_save_image](cci:1://file:///Users/himanshugupta/Developer/wagtail-wordpress-import/wagtail_wordpress_import/block_builder_defaults.py:105:0-160:25) or shortcode handlers) are now properly recorded in the CSV logs instead of being printed to stdout or lost.

## Testing & Verification

I have verified these changes using custom reproduction scripts to simulate the failure scenarios:
-   **CSV Output:** Verified `pagelink_errors-report.csv` now contains the correct data for broken links.
-   **Zero-width / Corrupted Images:** Verified that the importer no longer crashes and instead logs the error to `images-report.csv`.
-   **Missing Images in Captions:** Verified that the import continues and a raw HTML placeholder is inserted.

## Checklist
- [x] Code follows the project's coding style
- [x] Logging refactored and verified
- [x] Sub-issues #142, #145, #171 resolved